### PR TITLE
Update after-install.sh - fix log file permissions

### DIFF
--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -1,5 +1,5 @@
 chown -R logstash:logstash /usr/share/logstash
-chown logstash /var/log/logstash
+chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 0644 /etc/logrotate.d/logstash
 sed -i \


### PR DESCRIPTION
When installing Logstash (after previous removal of the Logstash RPM), there is a chance that there are old log files without proper owner.
Running Logstash as service, it may want to append data to these log files. Consequently, the logstash service does not start because it doesn't have write permissions to that files. This patch sets the (new) user logstash to own these historic files.

I have this problem w/ logstash 2.3, however, I believe it affects all versions RPM packaging.

This is to fix https://github.com/elastic/logstash/issues/5637.